### PR TITLE
Add missing languages from documentation

### DIFF
--- a/i18n.md
+++ b/i18n.md
@@ -7,9 +7,14 @@ DefaultContentLanguage = "en"
 Set `DefaultContentLanguage` to desired language:
 
 * `en`: English
-* `zh-cn`: Chinese
 * `fr`: French
+* `id`: Indonesian
 * `ja`: Japanese
+* `ko`: Korean
+* `pt-br`: Portuguese
+* `zh-cn`: Chinese
+* `es`: Spanish
+* `de`: German
 
 Translation files are stored under `i18n` folder, PRs for more language support are welcome 😉.
 


### PR DESCRIPTION
Since I've just added German translations with a PR on the theme repo I thought that keeping the docs up-to-date also wouldn't be bad, since it's great that you went the extra mile and made use of GitBook.
The order is just how the languages are listed in the config file of the exampleSite.