### PR TITLE
Update example-custom-font-family-for-article-content.md

### DIFF
--- a/modify-theme/example-custom-font-family-for-article-content.md
+++ b/modify-theme/example-custom-font-family-for-article-content.md
@@ -15,7 +15,7 @@ Create `layouts/partials/head/custom.html` under your Hugo site folder, with fol
 <script>
 		(function () {
 		    const customFont = document.createElement('link');
-		    customFont.href = "<https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap>";
+		    customFont.href = "https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&display=swap";
 		
 		    customFont.type = "text/css";
 		    customFont.rel = "stylesheet";


### PR DESCRIPTION
"<>" in customFont.href is redundant. With "<>" brackets in customFont.href font change doesn't work.